### PR TITLE
Polylines (part 2)

### DIFF
--- a/scripts/depthmap.py
+++ b/scripts/depthmap.py
@@ -527,137 +527,119 @@ def apply_stereo_divergence_naive(original_image, normalized_depth, divergence_p
     else:  # none
         return derived_image
 
-@njit(fastmath=True, parallel=True)
+@njit(parallel=True)  # fastmath=True does not reasonable improve performance
 def apply_stereo_divergence_polylines(original_image, normalized_depth, divergence_px: float, fill_technique):
     # This code treats rows of the image as polylines
     # It generates polylines, morphs them (applies divergence) to them, and then rasterizes them
-    # Would be great to have some optimizations for it
-
-    # total_segments = 0
-    # visible_segments = np.zeros(abs(int(divergence_px)) + 3, dtype=np.int32)
-    # overlapping_segments = np.zeros(abs(int(divergence_px)) + 3, dtype=np.int32)
-    # insertion_sort_operations = 0
-
     EPSILON = 1e-7
+    PIXEL_HALF_WIDTH = 0.45 if fill_technique == 4 else 0.0
+
     h, w, c = original_image.shape
     derived_image = np.zeros_like(original_image)
-    SAMPLES = [1/6, 3/6, 5/6] if fill_technique == 3 else [0.1, 0.3, 0.5, 0.7, 0.9]
-
     for row in prange(h):
-        # generating the polyline
-        # format of each segment: new coordinate of first point, its divergence,
-        #                         new coordinate of second point, its divergence,
-        #                         original column of the first pixel, original column of the second pixel
-        # it is not guaranteed that first pixel is the left pixel
-        sg = np.zeros((0, 6), dtype=np.float_)
-        sg_end = 0
-        if fill_technique == 3:  # polylines_soft
-            sg = np.zeros((w + 3, 6), dtype=np.float_)
-            sg[sg_end] = [-3.0 * abs(divergence_px), -0.1, -1337.0, -0.1, 0.0, 0.0]
-            sg_end += 1
-            for col in range(0, w - 1):
-                ld = (1 - normalized_depth[row][col] ** 2) * divergence_px
-                rd = (1 - normalized_depth[row][col + 1] ** 2) * divergence_px
-                lx, rx = ld + col, rd + (col + 1)
-                sg[sg_end] = [lx, abs(ld), rx, abs(rd), float(col), float(col + 1)]
-                sg_end += 1
-                if col == 0:
-                    sg[0][2] = sg[1][0] + EPSILON
-            sg[sg_end] = [sg[sg_end - 1][2] - EPSILON, -0.1, w + 3.0 * abs(divergence_px), -0.1, w - 1, w - 1]
-            sg_end += 1
-        if fill_technique == 4:  # polylines_sharp
-            PIXEL_HALF_WIDTH = 0.45
-            sg = np.zeros((2 * w + 5, 6), dtype=np.float_)
-            sg[sg_end] = [-3.0 * abs(divergence_px), -0.1, -1337.0, -0.1, 0, 0]
-            sg_end += 1
-            for col in range(0, w):
-                # each pixel gets a segment
-                d = (1 - normalized_depth[row][col] ** 2) * divergence_px
-                center = col + d
-                fx = center - PIXEL_HALF_WIDTH - EPSILON
-                sx = center + PIXEL_HALF_WIDTH + EPSILON
+        # generating the vertices of the morphed polyline
+        # format: new coordinate of the vertex, divergence (closeness), column of pixel that contains the point's color
+        pt = np.zeros((5 + 2 * w, 3), dtype=np.float_)
+        pt_end: int = 0
+        pt[pt_end] = [-3.0 * abs(divergence_px), 0.0, 0.0]
+        pt_end += 1
+        for col in range(0, w):
+            coord_d = (1 - normalized_depth[row][col] ** 2) * divergence_px
+            coord_x = col + 0.5 + coord_d
+            if PIXEL_HALF_WIDTH < EPSILON:
+                pt[pt_end] = [coord_x, abs(coord_d), col]
+                pt_end += 1
+            else:
+                pt[pt_end] = [coord_x - PIXEL_HALF_WIDTH, abs(coord_d), col]
+                pt[pt_end + 1] = [coord_x + PIXEL_HALF_WIDTH, abs(coord_d), col]
+                pt_end += 2
+        pt[pt_end] = [w + 3.0 * abs(divergence_px), 0.0, w - 1]
+        pt_end += 1
 
-                if col == 0:
-                    sg[0][2] = fx + EPSILON
-                else:
-                    # each space between two adjacent pixels gets a segment
-                    sg[sg_end] = [(sg[sg_end - 1][0] + sg[sg_end-1][2]) / 2, sg[sg_end - 1][3] - EPSILON,
-                                  center, abs(d) - EPSILON,
-                                  col - 1, col]
-                    sg_end += 1
-
-                # each pixel gets a segment
-                sg[sg_end] = [fx, abs(d), sx, abs(d), col, col]
-                sg_end += 1
-
-            sg[sg_end] = [sg[sg_end - 1][2] - EPSILON, -0.1, w + 3.0 * abs(divergence_px), -0.1, w - 1, w - 1]
+        # generating the segments of the morphed polyline
+        # format: coord_x, coord_d, color_i of the first point, then the same for the second point
+        sg = np.zeros((2 * pt_end, 6), dtype=np.float_)
+        sg_end: int = 0
+        for i in range(pt_end - 1):
+            sg[sg_end] += np.concatenate((pt[i], pt[i + 1]))
             sg_end += 1
-        # total_segments += sg_end
+        # Here is an informal proof that this (morphed) polyline does not self-intersect:
+        # Draw a plot with two axes: coord_x and coord_d. Now draw the original line - it will be positioned at the
+        # bottom of the graph (that is, for every point coord_d == 0). Now draw the morphed line using the vertices of
+        # the original polyline. Observe that for each vertex in the new polyline, its increments
+        # (from the corresponding vertex in the old polyline) over coord_x and coord_d are in direct proportion.
+        # In fact, this proportion is equal for all the vertices and it is equal either -1 or +1,
+        # depending on the sign of divergence_px. Now draw the lines from each old vertex to a corresponding new vertex.
+        # Since the proportions are equal, these lines have the same angle with an axe and are parallel.
+        # So, these lines do not intersect. Now rotate the plot by 45 or -45 degrees and observe that
+        # each dot of the polyline is further right from the last dot,
+        # which makes it impossible for the polyline to self-interset. QED.
 
-        # sort segments using insertion sort
-        # has a very good performance in practice, since segments are almost sorted to begin with
+        # sort segments and points using insertion sort
+        # has a very good performance in practice, since these are almost sorted to begin with
+        for i in range(1, pt_end):
+            u = i - 1
+            while pt[u][0] > pt[u + 1][0] and 0 <= u:
+                pt[u], pt[u + 1] = np.copy(pt[u + 1]), np.copy(pt[u])
+                u -= 1
         for i in range(1, sg_end):
             u = i - 1
             while sg[u][0] > sg[u + 1][0] and 0 <= u:
-                # insertion_sort_operations += 1
                 sg[u], sg[u + 1] = np.copy(sg[u + 1]), np.copy(sg[u])
                 u -= 1
 
-        # Possible improvement: a more accurate logic instead of just sampling a region multiple times
         # rasterizing
         # at each point in time we keep track of segments that are "active" (or "current")
-        cs = np.zeros((5 * int(abs(divergence_px)) + 25, 6), dtype=np.float_)
-        cs_end = 0
-        seg_pointer = 0
-        for col in range(w):
-            # removing from current segments
-            cs_i = 0
-            while cs_i < cs_end:
-                if cs[cs_i][2] < col:
-                    cs[cs_i] = cs[cs_end - 1]
-                    cs_end -= 1
-                else:
-                    cs_i += 1
-
-            # adding to current segments
-            while seg_pointer < sg_end and sg[seg_pointer][0] < col + 1.0:
-                cs[cs_end] = sg[seg_pointer]
-                seg_pointer += 1
-                cs_end += 1
-
+        csg = np.zeros((5 * int(abs(divergence_px)) + 25, 6), dtype=np.float_)
+        csg_end: int = 0
+        sg_pointer: int = 0
+        # and index of the point that should be processed next
+        pt_i: int = 0
+        for col in range(w):  # iterate over regions (that will be rasterizeed into pixels)
             color = np.full(c, 0.5, dtype=np.float_)  # we start with 0.5 because of how floats are converted to ints
-            # visible_segments_col = np.zeros_like(samples)
-            for sample_i in range(len(SAMPLES)):
-                # finding the segment that is the closest at the position
-                sample = SAMPLES[sample_i]
-                pos = col + sample
-                best_i = 0
-                best_closeness = -1.1
-                for cs_i in range(cs_end):
-                    # interpolating, works regardless if first point is left point
-                    ip_k = (pos - cs[cs_i][0]) / (cs[cs_i][2] - cs[cs_i][0])
-                    closeness = (1.0 - ip_k) * cs[cs_i][1] + ip_k * cs[cs_i][3]
-                    if best_closeness < closeness and 0.0 < ip_k < 1.0:
-                        best_closeness = closeness
-                        best_i = cs_i
-                # overlapping_segments[cs_end] += 1
-                # assert best_closeness > 0
-                # visible_segments_col[sample_i] = best_i
+            while pt[pt_i][0] < col:
+                pt_i += 1
+            pt_i -= 1  # pt_i now points to the dot before the region start
+            # Finding segment' parts that contribute color to the region
+            while pt[pt_i][0] < col + 1:
+                coord_from = max(col, pt[pt_i][0]) + EPSILON
+                coord_to = min(col + 1, pt[pt_i + 1][0]) - EPSILON
+                significance = coord_to - coord_from
+                # the color at center point is the same as the average of color of segment part
+                coord_center = coord_from + 0.5 * significance
 
+                # adding semgents that now may contribute
+                while sg_pointer < sg_end and sg[sg_pointer][0] < coord_center:
+                    csg[csg_end] = sg[sg_pointer]
+                    sg_pointer += 1
+                    csg_end += 1
+                # removing segments that will no longer contribute
+                csg_i = 0
+                while csg_i < csg_end:
+                    if csg[csg_i][3] < coord_center:
+                        csg[csg_i] = csg[csg_end - 1]
+                        csg_end -= 1
+                    else:
+                        csg_i += 1
+                # finding the closest segment (segment with most divergence)
+                # note that this segment will be the closest from coord_from right up to coord_to, since there
+                # no new segments "appearing" inbetween these two and _the polyline does not self-intersect_
+                best_csg_i: int = 0
+                best_csg_closeness: float = -EPSILON
+                for csg_i in range(csg_end):
+                    ip_k = (coord_center - csg[csg_i][0]) / (csg[csg_i][3] - csg[csg_i][0])
+                    # assert 0.0 <= ip_k <= 1.0
+                    closeness = (1.0 - ip_k) * csg[csg_i][1] + ip_k * csg[csg_i][4]
+                    if best_csg_closeness < closeness and 0.0 < ip_k < 1.0:
+                        best_csg_closeness = closeness
+                        best_csg_i = csg_i
                 # getting the color
-                pos = col + sample
-                col_l, col_r = int(cs[best_i][4] + 0.001), int(cs[best_i][5] + 0.001)
-                ip_k = (pos - cs[best_i][0]) / (cs[best_i][2] - cs[best_i][0])
-                color += (original_image[row][col_l] * (1.0 - ip_k) + original_image[row][col_r] * ip_k) / len(SAMPLES)
-
-            # visible_segments[len(np.unique(visible_segments_col))] += 1
+                ip_k = (coord_center - csg[best_csg_i][0]) / (csg[best_csg_i][3] - csg[best_csg_i][0])
+                col_l: int = int(csg[best_csg_i][2] + EPSILON)
+                col_r: int = int(csg[best_csg_i][5] + EPSILON)
+                color += (original_image[row][col_l] * (1.0 - ip_k) + original_image[row][col_r] * ip_k) * significance
+                pt_i += 1
             derived_image[row][col] = np.asarray(color, dtype=np.uint8)
-
-    # print(f'image dimensions: h:{h}, w:{w}, total:{h*w}')
-    # print('total segments: ', int(total_segments))
-    # print('overlapping segments: ', list(overlapping_segments))
-    # print('visible segments: ', list(visible_segments))
-    # print('insertion sort operations: ', insertion_sort_operations)
     return derived_image
 
 @njit(parallel=True)


### PR DESCRIPTION
Yep, turned out a better algorithm, that I could not think of in half a week, exists. In this new version the borders in soft mode are more soft and in sharp mode more sharp - borders overall are more accurate, there certainly is less staircase effect. Performance penalty is ~30% according to my tests (excluding numba compilation, including running res101 without BOOST), which is somewhat disappointing to me considering I expected to have a 25%+ speedup.

The code is quite different, but algorithmically the new thing is largely similar to the old one. The difference is that this version picks better sampling points and weights their contribution to the pixel color appropriately. The sampling in the previous version had seemed to me like a hack from the get-go. If my theory and code are correct, the new version is equivalent to sampling every pixel >100 times. I am happy with the quality of this _row-based_ filling algorithm, I think it is unlikely that I will try to make a better-quality row-based algorithm.

If you merge this, could you please merge it "silently", with no mention in the change-log nor version number increment?

Happy new year!