### PR TITLE
Add support for NumPy 1.24.* (pt. 2)

### DIFF
--- a/install.py
+++ b/install.py
@@ -11,37 +11,36 @@ if not launch.is_installed('packaging'):
     launch.run_pip("install packaging", "packaging requirement for depthmap script")
 from packaging.version import Version
 
+def ensure(module_name, min_version=None):
+    if launch.is_installed(module_name):
+        if min_version is None or Version(importlib_metadata.version(module_name)) >= Version(min_version):
+            return
+    cmd = f'install "{module_name}>={min_version}"' if min_version is not None else f'install {module_name}'
+    msg = f'{module_name} {min_version + " " if min_version is not None else ""}requirement for depthmap script'
+    launch.run_pip(cmd, msg)
+
 if not launch.is_installed("timm"): #0.6.7
     launch.run_pip('install --force-reinstall "timm==0.6.12"', "timm requirement for depthmap script")
 
-if not launch.is_installed("matplotlib"):
-    launch.run_pip("install matplotlib", "matplotlib requirement for depthmap script")
+ensure('matplotlib')
 
-if not launch.is_installed("trimesh"):
-    launch.run_pip("install trimesh", "requirements for depthmap script")
-    
-if not launch.is_installed("numba") or Version(importlib_metadata.version("numba")) < Version("0.57.0"):
-    launch.run_pip('install "numba>=0.57.0"', "numba requirement for depthmap script")
-if not launch.is_installed("vispy"):
-    launch.run_pip("install vispy", "vispy requirement for depthmap script")
+ensure('trimesh')
 
-if not launch.is_installed("rembg"):
-    launch.run_pip("install rembg", "rembg requirement for depthmap script")
+ensure('numba', '0.57.0')
+ensure('vispy')
+
+ensure('rembg')
 
 if not launch.is_installed("moviepy"):
     launch.run_pip('install "moviepy==1.0.2"', "moviepy requirement for depthmap script")
-if not launch.is_installed("transforms3d"):
-    launch.run_pip("install transforms3d", "transforms3d requirement for depthmap script")
-if not launch.is_installed("imageio"): #2.4.1
-    launch.run_pip("install imageio", "imageio requirement for depthmap script")
-if not launch.is_installed("imageio-ffmpeg"):
-    launch.run_pip("install imageio-ffmpeg", "imageio-ffmpeg requirement for depthmap script")
+ensure('transforms3d', '0.4.1')
+
+ensure('imageio')  # 2.4.1
+ensure('imageio-ffmpeg')
 if not launch.is_installed("networkx"):
     launch.run_pip('install install "networkx==2.5"', "networkx requirement for depthmap script")
 if platform.system() == 'Windows':
-    if not launch.is_installed("pyqt5"):
-        launch.run_pip("install pyqt5", "pyqt5 requirement for depthmap script")
+    ensure('pyqt5')
 
 if platform.system() == 'Darwin':
-    if not launch.is_installed("pyqt6"):
-        launch.run_pip("install pyqt6", "pyqt6 requirement for depthmap script")
+    ensure('pyqt6')


### PR DESCRIPTION
Just after I thought it worked, I noticed another issue. 😅 
Somehow my venv ended up in a state where it had transforms3d==0.2.1 installed (which is many years old and does not work with NumPy 1.24.*). I bumped it to 0.4.1. It is the latest version and it worked on my machine. Not sure if it works elsewhere, too, since I could not find where this module is used. So probably requires some testing.

Also, did some refactoring on the dependency installation logic. It could be refactored further (where it installs the exact versions), but does not look necessary to my eye right now.

@thygate 

P.S. Thanks for merging the previous MR so fast!