### PR TITLE
Update requirements.txt

### DIFF
--- a/scripts/inpaint/requirements.txt
+++ b/scripts/inpaint/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python==4.2.0.32
 vispy==0.6.4
 moviepy==1.0.2
-transforms3d==0.3.1
+transforms3d==0.4.1
 networkx==2.3
 cynetworkx
 scikit-image


### PR DESCRIPTION
fixed transforms3d version old version was using deprecated numpy causing errors.  


 AttributeError: module 'numpy' has no attribute 'float'.
 `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.