### PR TITLE
small fixes to normal maps

### DIFF
--- a/src/normalmap_generation.py
+++ b/src/normalmap_generation.py
@@ -16,8 +16,9 @@ def create_normalmap(depthmap,
     # TODO: Tiling can be improved (gradients could be matched).
     # TODO: Implement bilateral filtering (16 bit deflickering)
 
+    # We invert by default, maybe there is a negative sign hiding somewhere
     normalmap = depthmap if invert else depthmap * (-1.0)
-    normalmap = normalmap/256
+    normalmap = normalmap / 256.0
     # pre blur (only blurs z-axis)
     if pre_blur is not None and pre_blur > 0:
         normalmap = cv2.GaussianBlur(normalmap, (pre_blur, pre_blur), pre_blur)

--- a/src/normalmap_generation.py
+++ b/src/normalmap_generation.py
@@ -3,7 +3,7 @@ import cv2
 from PIL import Image
 
 def create_normalmap(depthmap,
-                     pre_blur: int | None = None, sobel_gradient: int | None = 3, post_blur: int | None = None,
+                     pre_blur = None, sobel_gradient = 3, post_blur = None,
                      invert=False):
     """Generates normalmaps.
     :param depthmap: depthmap that will be used to generate normalmap
@@ -16,7 +16,8 @@ def create_normalmap(depthmap,
     # TODO: Tiling can be improved (gradients could be matched).
     # TODO: Implement bilateral filtering (16 bit deflickering)
 
-    normalmap = depthmap * (-1.0) if invert else depthmap
+    normalmap = depthmap if invert else depthmap * (-1.0)
+    normalmap = normalmap/256
     # pre blur (only blurs z-axis)
     if pre_blur is not None and pre_blur > 0:
         normalmap = cv2.GaussianBlur(normalmap, (pre_blur, pre_blur), pre_blur)


### PR DESCRIPTION
This fixes some of the things I mentioned here https://github.com/thygate/stable-diffusion-webui-depthmap-script/issues/299

The invert step looks a little strange but I think there's a hidden negative sign somewhere. Greens should be top, reds bottom right, blues bottom left.