### PR TITLE
Fix generate 3d inpainted mesh 4-channel png error

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -450,6 +450,9 @@ def run_3dphoto(device, img_rgb, img_depth, inputnames, outpath, gen_inpainted_m
 
             # rgb input
             img = np.asarray(img_rgb[count])
+            if len(img.shape) > 2 and img.shape[2] == 4:
+                # convert the image from RGBA2RGB
+                img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
 
             # run sparse bilateral filter
             config['sparse_iter'] = 5


### PR DESCRIPTION
Use "Batch Process" mode to upload images, np.asarray will generate 4-channel images. this results in "shape mismatch: value array of shape (3,) could not be broadcast to indexing result of shape" errors when "vis_image[u_over > 0] = np.array([0, 0, 0])".
Converting a four-channel image to a three-channel image before use can solve this problem.