### PR TITLE
marigold_ensemble integer fix

### DIFF
--- a/src/backbone.py
+++ b/src/backbone.py
@@ -42,6 +42,9 @@ try:
                 c = get_cmd_opt(s, None)
             if c is not None:
                 ops[s] = c
+        # sanitize for integers.
+        for s in ['marigold_ensembles', 'marigold_steps']:
+            ops[s] = int(ops[s])
         return ops
 
 

--- a/src/backbone.py
+++ b/src/backbone.py
@@ -44,7 +44,8 @@ try:
                 ops[s] = c
         # sanitize for integers.
         for s in ['marigold_ensembles', 'marigold_steps']:
-            ops[s] = int(ops[s])
+            if s in ops:
+                ops[s] = int(ops[s])
         return ops
 
 


### PR DESCRIPTION
For the integer issue #388

This is probably the best place to cast to integers. Feel free to modify any other details.

---
The float16 does seem to be working. The vram significantly lower, although I keep getting an erroneous error message. 
```
Pipelines loaded with `torch_dtype=torch.float16` cannot run with `cpu` device. It is not recommended to move them to `cpu` as running them will fail. Please make sure to use an accelerator to run the pipeline in inference, due to the lack of support for`float16` operations on this device in PyTorch. Please, remove the `torch_dtype=torch.float16` argument, or use another device for inference.
```
Hopefully this will be fixed by future marigold updates.