### PR TITLE
fix: input_depths include PIL Image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ imageio-ffmpeg
 networkx>=2.5
 pyqt5; sys_platform == 'windows'
 pyqt6; sys_platform != 'windows'
+einops

--- a/src/video_mode.py
+++ b/src/video_mode.py
@@ -147,6 +147,7 @@ def gen_video(video, outpath, inp, custom_depthmap=None, colorvids_bitrate=None,
 
         gen_obj = core.core_generation_funnel(None, input_images, None, None, first_pass_inp)
         input_depths = [x[2] for x in list(gen_obj)]
+        input_depths = [x for x in input_depths if isinstance(x, np.ndarray) ]
         input_depths = process_predicitons(input_depths, smoothening)
     else:
         print('Using custom depthmap video')


### PR DESCRIPTION
Only in standalone mode, when I generate depth and stereo video, I get 'PIL Image' in input_depths( line  149, input_depths = [x[2] for x in list(gen_obj)] in video_mode.py file).

I use docker image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime
